### PR TITLE
update accessibility elements on style or data change

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 import xtend from 'xtend';
 import bbox from '@turf/bbox';
+import debounce from 'lodash/debounce';
 
 export default class MapboxAccessibility {
   constructor(options) {
@@ -33,6 +34,9 @@ export default class MapboxAccessibility {
   };
 
   queryFeatures = () => {
+    this._debouncedQueryFeatures.cancel();
+    this.clearMarkers();
+
     this.features = this.map.queryRenderedFeatures({ layers: this.options.layers });
     this.features.map((feature) => {
       let { width, height } = this.options;
@@ -70,19 +74,36 @@ export default class MapboxAccessibility {
     });
   };
 
+  _movestart = () => {
+    this._debouncedQueryFeatures.cancel();
+    this.clearMarkers();
+  };
+
+  _render = () => {
+    if (this.map.areTilesLoaded() && this.map.loaded() && !this.map.isMoving()) {
+      this._debouncedQueryFeatures();
+    }
+  };
+
   onAdd(map) {
     this.map = map;
-    this.queryFeatures();
-    this.map.on('moveend', this.queryFeatures);
-    this.map.on('movestart', this.clearMarkers);
+
+    this._debouncedQueryFeatures = debounce(this.queryFeatures, 100);
+
+    this.map.on('movestart', this._movestart);
+    this.map.on('moveend', this._render);
+    this.map.on('render', this._render);
+
     this.container = document.createElement('div');
     return this.container;
   }
 
   onRemove() {
     this.container.parentNode.removeChild(this.container);
-    this.map.off('moveend', this.queryFeatures);
-    this.map.off('movestart', this.clearMarkers);
+    this.map.off('movestart', this._movestart);
+    this.map.off('moveend', this._render);
+    this.map.off('render', this._render);
+    this._debouncedQueryFeatures.cancel();
     delete this.map;
   }
 }

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ export default class MapboxAccessibility {
   };
 
   _render = () => {
-    if (this.map.areTilesLoaded() && this.map.loaded() && !this.map.isMoving()) {
+    if (!this.map.isMoving()) {
       this._debouncedQueryFeatures();
     }
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -325,7 +325,7 @@
         "convert-source-map": "1.5.0",
         "fs-readdir-recursive": "1.1.0",
         "glob": "7.1.2",
-        "lodash": "4.17.4",
+        "lodash": "4.17.10",
         "output-file-sync": "1.1.2",
         "path-is-absolute": "1.0.1",
         "slash": "1.0.0",
@@ -363,7 +363,7 @@
         "convert-source-map": "1.5.0",
         "debug": "2.6.9",
         "json5": "0.5.1",
-        "lodash": "4.17.4",
+        "lodash": "4.17.10",
         "minimatch": "3.0.4",
         "path-is-absolute": "1.0.1",
         "private": "0.1.8",
@@ -382,7 +382,7 @@
         "babel-types": "6.26.0",
         "detect-indent": "4.0.0",
         "jsesc": "1.3.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.10",
         "source-map": "0.5.7",
         "trim-right": "1.0.1"
       }
@@ -408,7 +408,7 @@
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "lodash": "4.17.10"
       }
     },
     "babel-helper-function-name": {
@@ -462,7 +462,7 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "lodash": "4.17.10"
       }
     },
     "babel-helper-replace-supers": {
@@ -553,7 +553,7 @@
         "babel-template": "6.26.0",
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "lodash": "4.17.10"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -839,7 +839,7 @@
         "babel-runtime": "6.26.0",
         "core-js": "2.5.1",
         "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.10",
         "mkdirp": "0.5.1",
         "source-map-support": "0.4.18"
       }
@@ -864,7 +864,7 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "lodash": "4.17.4"
+        "lodash": "4.17.10"
       }
     },
     "babel-traverse": {
@@ -881,7 +881,7 @@
         "debug": "2.6.9",
         "globals": "9.18.0",
         "invariant": "2.2.2",
-        "lodash": "4.17.4"
+        "lodash": "4.17.10"
       }
     },
     "babel-types": {
@@ -892,7 +892,7 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
-        "lodash": "4.17.4",
+        "lodash": "4.17.10",
         "to-fast-properties": "1.0.3"
       }
     },
@@ -1866,7 +1866,7 @@
         "js-yaml": "3.11.0",
         "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.10",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "natural-compare": "1.4.0",
@@ -3605,7 +3605,7 @@
         "cli-width": "2.2.0",
         "external-editor": "2.2.0",
         "figures": "2.0.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.10",
         "mute-stream": "0.0.7",
         "run-async": "2.3.0",
         "rx-lite": "4.0.8",
@@ -4012,10 +4012,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-      "dev": true
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash.memoize": {
       "version": "3.0.4",
@@ -5817,7 +5816,7 @@
         "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
         "chalk": "2.4.1",
-        "lodash": "4.17.4",
+        "lodash": "4.17.10",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
       },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@turf/bbox": "^6.0.1",
+    "lodash": "^4.17.10",
     "xtend": "^4.0.1"
   }
 }


### PR DESCRIPTION
closes #8 

The accessibility elements should be updated:

1. upon style change (setPaintProperty, setStyle, addLayer etc as this changes what's visible)
2. upon data change (eg. setData, or tiles refreshing due to their cache timeout, eg. live traffic)
4. when the camera changes (moveend) if 1 or 2 happen while the map is still moving, the update should be delayed until moveend.

Initially I thought the 'render' event was a problem since it fires very frequently and not just at the end when everything is done, but I think we can use this as a feature, so that if a tile is taking a long time to download, the accessibility elements can still be updated even if some data is still loading.