### PR TITLE
Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
     "@turf/bbox": "^6.0.1",
     "lodash": "^4.17.10",
     "xtend": "^4.0.1"
+  },
+  "peerDependencies": {
+    "mapbox-gl": ">=0.32.1 <2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babelify": "^8.0.0",
     "brfs": "^2.0.1",
-    "budo": "^11.5.0",
+    "budo": "^11.6.2",
     "eslint": "^4.19.1",
     "insert-css": "^2.0.0",
     "mapbox-gl": "^0.44.2"


### PR DESCRIPTION
- Add `mapbox-gl` as a peer dependency so npm will ensure the correct version of GL JS is installed alongside the plugin
- Update other dependencies to fix `npm audit` vulnerabilities
- Add `.gitignore` to ignore `node_modules/` directory