### PR TITLE
Convert proposed class property arrow funcs;

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 _site/
 example/bundle.js
+dist/

--- a/index.js
+++ b/index.js
@@ -20,9 +20,14 @@ export default class MapboxAccessibility {
     }
 
     this.options = xtend(defaultOptions, options);
+
+    this.clearMarkers = this.clearMarkers.bind(this);
+    this.queryFeatures = this.queryFeatures.bind(this);
+    this._movestart = this._movestart.bind(this);
+    this._render = this._render.bind(this);
   }
 
-  clearMarkers = () => {
+  clearMarkers() {
     if (this.features) {
       this.features.forEach(feature => {
         if (feature.marker) {
@@ -33,7 +38,7 @@ export default class MapboxAccessibility {
     }
   };
 
-  queryFeatures = () => {
+  queryFeatures() {
     this._debouncedQueryFeatures.cancel();
     this.clearMarkers();
 
@@ -74,12 +79,12 @@ export default class MapboxAccessibility {
     });
   };
 
-  _movestart = () => {
+  _movestart() {
     this._debouncedQueryFeatures.cancel();
     this.clearMarkers();
   };
 
-  _render = () => {
+  _render() {
     if (!this.map.isMoving()) {
       this._debouncedQueryFeatures();
     }


### PR DESCRIPTION
I was having trouble getting this to build because babel did not like the syntax of the class property _arrow functions_. Other ES features work.

Instead I just moved these array function _methods_ into to the constructor until we can understand why this babel feature isn’t working. This is what would happen if babel transpilation worked.

This is a workaround to get the thing to _build_. This change helps:

1. Others get up and running
2. Makes it possible to import through webpack

One possible step forward towards closing #17