### PR TITLE
Upgrade babel to 7+; prefer class properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,14 +20,9 @@ export default class MapboxAccessibility {
     }
 
     this.options = xtend(defaultOptions, options);
-
-    this.clearMarkers = this.clearMarkers.bind(this);
-    this.queryFeatures = this.queryFeatures.bind(this);
-    this._movestart = this._movestart.bind(this);
-    this._render = this._render.bind(this);
   }
 
-  clearMarkers() {
+  clearMarkers = () => {
     if (this.features) {
       this.features.forEach(feature => {
         if (feature.marker) {
@@ -36,9 +31,9 @@ export default class MapboxAccessibility {
         }
       });
     }
-  };
+  }
 
-  queryFeatures() {
+  queryFeatures = () => {
     this._debouncedQueryFeatures.cancel();
     this.clearMarkers();
 
@@ -77,18 +72,18 @@ export default class MapboxAccessibility {
       this.map.getCanvasContainer().appendChild(feature.marker);
       return feature;
     });
-  };
+  }
 
-  _movestart() {
+  _movestart = () => {
     this._debouncedQueryFeatures.cancel();
     this.clearMarkers();
-  };
+  }
 
-  _render() {
+  _render = () => {
     if (!this.map.isMoving()) {
       this._debouncedQueryFeatures();
     }
-  };
+  }
 
   onAdd(map) {
     this.map = map;

--- a/package.json
+++ b/package.json
@@ -22,18 +22,18 @@
   },
   "babel": {
     "presets": [
-      "es2015"
+      "@babel/preset-env"
     ],
     "plugins": [
-      "transform-class-properties"
+      "@babel/plugin-proposal-class-properties"
     ]
   },
   "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "babel-eslint": "^8.2.3",
-    "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-preset-es2015": "^6.24.1",
-    "babelify": "^8.0.0",
+    "@babel/core": "^7.8.3",
+    "babel-eslint": "^10.0.3",
+    "@babel/plugin-proposal-class-properties": "^7.8.3",
+    "@babel/preset-env": "^7.8.3",
+    "babelify": "^10.0.0",
     "brfs": "^2.0.2",
     "budo": "^11.6.2",
     "eslint": "^4.19.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "budo example/index.js --serve=example/bundle.js --live",
-    "build": "browserify example/index.js > example/bundle.js && rm -rf _site && mkdir -p _site && cp -R example/ _site/",
+    "build": "rollup -c",
     "test": "eslint index.js"
   },
   "repository": {
@@ -30,15 +30,19 @@
   },
   "devDependencies": {
     "@babel/core": "^7.8.3",
-    "babel-eslint": "^10.0.3",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/preset-env": "^7.8.3",
+    "@rollup/plugin-commonjs": "^11.0.1",
+    "@rollup/plugin-node-resolve": "^7.0.0",
+    "babel-eslint": "^10.0.3",
     "babelify": "^10.0.0",
     "brfs": "^2.0.2",
     "budo": "^11.6.2",
     "eslint": "^4.19.1",
     "insert-css": "^2.0.0",
-    "mapbox-gl": "^0.44.2"
+    "mapbox-gl": "^0.44.2",
+    "rollup-plugin-babel": "^4.3.3",
+    "rollup": "^1.29.1"
   },
   "dependencies": {
     "@turf/bbox": "^6.0.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,22 @@
+import babel from 'rollup-plugin-babel';
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+
+export default {
+  input: ['index.js'],
+  output: {
+    name: 'MapboxAccessibility',
+    file: 'dist/mapbox-gl-accessibility.js',
+    format: 'umd',
+    sourcemap: true,
+    indent: false,
+  },
+  treeshake: true,
+  plugins: [
+    // rollup requires a babel passthrough to transpile special
+    // proposed "class properties" syntax
+    babel(),
+    resolve(),
+    commonjs(),
+  ],
+};


### PR DESCRIPTION
I ran into some snags trying to get a testing environment setup in a way that mimics other mapbox plugins (mapbox-gl-draw).

This change does a few things:
1. Updates all babel package naming and features to Babel 7+. Specifically, this moves to @babel/preset-env, which tries to auto-detect needed transpilations.
2. Swaps the old transform-class-properties package naming to the new @babel style.
3. Removes babel-cli
4. Reverts 04a9bf67831f3eaadb63eab22ebf2291cea1b197 by switching _back_ to class property proposal syntax, which implicitly handles method binding.

Instead of a workaround, this PR addresses the original issue reported in #17.